### PR TITLE
ci: publish with npm to attach provenance via token auth

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -167,7 +167,7 @@ jobs:
             PUBLISH_OPTS="$PUBLISH_OPTS --tag $PRERELEASE_TAG"
             echo "📌 Publishing with tag: $PRERELEASE_TAG"
           fi
-          pnpm publish $PUBLISH_OPTS
+          npm publish $PUBLISH_OPTS
           echo "✅ Published switch-ts@$VERSION"
 
   finalize:


### PR DESCRIPTION
pnpm publish attempts OIDC trusted publishing first and fails when no trusted publisher is configured (ERR_PNPM_AUTH_TOKEN_EXCHANGE 404). npm publish authenticates with the token and attaches provenance via the id-token attestation — no trusted-publisher setup needed. Verified that npm publish does not trip the pnpm devEngines policy (only npm pack does).