### PR TITLE
ci: switch npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -157,7 +157,8 @@ jobs:
           fi
           # Trusted publishing (OIDC): npm exchanges the workflow id-token for
           # a short-lived, package-scoped registry credential, so no
-          # NODE_AUTH_TOKEN is needed. Provenance is attached automatically.
+          # NODE_AUTH_TOKEN is needed. `--provenance` attaches a provenance
+          # attestation via the same id-token.
           PUBLISH_OPTS="--provenance --access public"
           if [ -n "$PRERELEASE_TAG" ]; then
             PUBLISH_OPTS="$PUBLISH_OPTS --tag $PRERELEASE_TAG"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -143,13 +143,6 @@ jobs:
       - name: Publish
         env:
           VERSION: ${{ needs.validate.outputs.version }}
-          # Token auth (granular access token with publish rights to this
-          # package). npm trusted publishing (OIDC) still requires linking
-          # this package to the workflow in npmjs.com's settings; until that
-          # is configured, the token authenticates the publish, while
-          # `--provenance` independently attaches a provenance attestation
-          # via the workflow's id-token permission.
-          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
         run: |
           PRERELEASE_TAG=""
           if [[ "$VERSION" == *-* ]]; then
@@ -162,7 +155,10 @@ jobs:
               PRERELEASE_TAG="next"
             fi
           fi
-          PUBLISH_OPTS="--provenance --access public --no-git-checks"
+          # Trusted publishing (OIDC): npm exchanges the workflow id-token for
+          # a short-lived, package-scoped registry credential, so no
+          # NODE_AUTH_TOKEN is needed. Provenance is attached automatically.
+          PUBLISH_OPTS="--provenance --access public"
           if [ -n "$PRERELEASE_TAG" ]; then
             PUBLISH_OPTS="$PUBLISH_OPTS --tag $PRERELEASE_TAG"
             echo "📌 Publishing with tag: $PRERELEASE_TAG"


### PR DESCRIPTION
## Summary

- Switch the npm publish workflow from token auth (`secrets.npm_token`) to **npm OIDC trusted publishing**.
- npm exchanges the workflow `id-token` for a short-lived, package-scoped registry credential, so no `NODE_AUTH_TOKEN` is needed. This removes the 2FA/OTP prompt that blocked token-based CI publishing (`EOTP`).
- Drop the pnpm-only `--no-git-checks` flag from `npm publish` (no-op for npm).
- Provenance is still attached (automatic for a public package published via trusted publishing; `--provenance` retained).

The trusted publisher is configured per package in npmjs.com settings (repo + `npm-publish.yml` + the `npm` environment). CI-only change; no runtime/source impact.