### PR TITLE
ci: disable setup-node package-manager cache for OIDC publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -111,7 +111,10 @@ jobs:
         with:
           node-version-file: .node-version
           registry-url: 'https://registry.npmjs.org'
-          cache: 'pnpm'
+          # OIDC trusted publishing needs a clean credential state; a restored
+          # setup-node cache leaves a dummy NODE_AUTH_TOKEN in .npmrc that makes
+          # npm skip the OIDC token exchange. Disable caching in this job only.
+          package-manager-cache: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

- Fix OIDC trusted publishing: the publish job disabled OIDC by enabling setup-node caching (`cache: pnpm`), which leaves a dummy `NODE_AUTH_TOKEN` in `.npmrc`. npm used that dummy token and skipped the OIDC token exchange, failing with `E404`.
- Per [npm/setup-node trusted publishing guide](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#publishing-to-npm-with-trusted-publisher-oidc), the OIDC publish job must set `package-manager-cache: false` (with `registry-url` kept).
- Only the **publish** job changes; the test job keeps caching.

CI-only change.