### PR TITLE
ci: remove registry-url so setup-node does not block OIDC

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -110,10 +110,10 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .node-version
-          registry-url: 'https://registry.npmjs.org'
-          # OIDC trusted publishing needs a clean credential state; a restored
-          # setup-node cache leaves a dummy NODE_AUTH_TOKEN in .npmrc that makes
-          # npm skip the OIDC token exchange. Disable caching in this job only.
+          # No registry-url: setup-node v6.4.0 has no OIDC support and, when given
+          # a registry, injects a dummy NODE_AUTH_TOKEN into .npmrc that makes npm
+          # skip the OIDC token exchange and fail with E404. Without it, npm uses
+          # the default registry and authenticates via the workflow id-token.
           package-manager-cache: false
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

- Root cause of the OIDC publish `E404`: `actions/setup-node@v6.4.0` (latest release) has **no OIDC/trusted-publishing support**. Its `authutil.ts` unconditionally runs when `registry-url` is set and does `exportVariable('NODE_AUTH_TOKEN', process.env.NODE_AUTH_TOKEN || 'XXXXX-XXXXX-XXXXX-XXXXX')`, injecting a dummy token into `.npmrc`. npm then authenticates with the dummy token and never performs the OIDC exchange.\n- Fix: **remove `registry-url`** from the publish job. Without it, `authutil` does not run, no dummy token or `.npmrc` is written, and npm authenticates via the workflow `id-token` against the default registry.\n- `package-manager-cache: false` is retained (harmless).\n\nCI-only change. This is the corrected follow-up to #287 (which added `package-manager-cache: false` but did not resolve the E404).