### PR TITLE
ci: force empty NODE_AUTH_TOKEN so setup-node v6.4.0 does OIDC

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -110,10 +110,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version-file: .node-version
-          # No registry-url: setup-node v6.4.0 has no OIDC support and, when given
-          # a registry, injects a dummy NODE_AUTH_TOKEN into .npmrc that makes npm
-          # skip the OIDC token exchange and fail with E404. Without it, npm uses
-          # the default registry and authenticates via the workflow id-token.
+          registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
 
       - name: Install dependencies
@@ -146,6 +143,11 @@ jobs:
       - name: Publish
         env:
           VERSION: ${{ needs.validate.outputs.version }}
+          # setup-node v6.4.0 injects a dummy NODE_AUTH_TOKEN when registry-url is
+          # set; force it empty so the .npmrc _authToken resolves to empty and npm
+          # performs the OIDC trusted-publishing exchange via the workflow id-token
+          # instead of authenticating with the dummy token.
+          NODE_AUTH_TOKEN: ''
         run: |
           PRERELEASE_TAG=""
           if [[ "$VERSION" == *-* ]]; then


### PR DESCRIPTION
## Summary

- Final fix for the OIDC publish failure. `actions/setup-node@v6.4.0` (latest release) has no OIDC support: its `authutil.ts` does `exportVariable('NODE_AUTH_TOKEN', process.env.NODE_AUTH_TOKEN || 'XXXXX-XXXXX-XXXXX-XXXXX')`, always injecting a dummy token when `registry-url` is set.\n- Evidence: with `registry-url` → dummy token → `E404`; without `registry-url` → no registry config → npm never tries OIDC → `ENEEDAUTH`.\n- Fix: keep `registry-url` and set `NODE_AUTH_TOKEN: ''` in the publish step. The `.npmrc` `_authToken=${NODE_AUTH_TOKEN}` then resolves to empty, and npm performs the OIDC trusted-publishing exchange. This matches `setup-node@main`, which only exports `NODE_AUTH_TOKEN` when the user supplies it.\n\nSupersedes #287 and #288. CI-only change.