### PR TITLE
ci: add temporary verbose logging to diagnose OIDC exchange

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -169,7 +169,9 @@ jobs:
             PUBLISH_OPTS="$PUBLISH_OPTS --tag $PRERELEASE_TAG"
             echo "📌 Publishing with tag: $PRERELEASE_TAG"
           fi
-          npm publish $PUBLISH_OPTS
+          # TEMP diagnostic: --loglevel verbose surfaces npm's silent OIDC
+          # token-exchange failure (lib/utils/oidc.js logs it at verbose).
+          npm publish $PUBLISH_OPTS --loglevel verbose
           echo "✅ Published switch-ts@$VERSION"
 
   finalize:


### PR DESCRIPTION
Temporary diagnostic to surface npm's silent OIDC token-exchange failure (logged only at verbose level in lib/utils/oidc.js). Will be reverted after diagnosis.