### PR TITLE
build: trust the committed lockfile during install

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,13 @@
 pmOnFail: ignore
 
-# Renovate resolves and pins every dependency itself, so CI does not re-apply
-# `minimumReleaseAge` to entries the lockfile already records. Without this
-# setting `pnpm install --frozen-lockfile` rejects the lockfile Renovate wrote
-# whenever a release is under a day old. Resolution-time cooldown and
-# Renovate's own three-day hold remain in place.
+# Trust the resolutions the lockfile already records. The setting applies to
+# every install, local and CI alike, so none of them re-apply
+# `minimumReleaseAge` to lockfile entries. Renovate writes the lockfile and
+# opens the pull request within hours of a publish, so without this setting
+# `pnpm install --frozen-lockfile` rejects the lockfile Renovate just produced.
+# The cooldown still applies when resolving a new version, and Renovate's
+# three-day hold still gates the merge. The accepted trade-off is that a
+# lockfile arriving through a pull request is no longer re-audited.
 trustLockfile: true
 
 # Packages allowed to run install scripts (pnpm 11 blocks by default).

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,11 @@
 pmOnFail: ignore
-# One-time cooldown exemptions (pnpm minimumReleaseAge): these exact versions were <24h old at adoption time; safe to delete once aged.
-minimumReleaseAgeExclude:
-  - '@arethetypeswrong/cli@0.18.5'
-  - '@arethetypeswrong/core@0.18.5'
+
+# Renovate resolves and pins every dependency itself, so CI does not re-apply
+# `minimumReleaseAge` to entries the lockfile already records. Without this
+# setting `pnpm install --frozen-lockfile` rejects the lockfile Renovate wrote
+# whenever a release is under a day old. Resolution-time cooldown and
+# Renovate's own three-day hold remain in place.
+trustLockfile: true
 
 # Packages allowed to run install scripts (pnpm 11 blocks by default).
 allowBuilds:


### PR DESCRIPTION
## Summary

- Set `trustLockfile: true` in `pnpm-workspace.yaml` so `pnpm install --frozen-lockfile` stops re-verifying the release age of every lockfile entry.

## Why

pnpm 11 turned supply-chain protection on by default: `minimumReleaseAge` defaults to `1440` (one day) and `trustLockfile` defaults to `false`. Every install therefore re-applies the age check to the whole lockfile, and rejects entries published less than a day ago:

```
✗ Lockfile failed supply-chain policy check
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION] lockfile entries failed verification:
  <package>@<version> was published at <timestamp>,
    within the minimumReleaseAge cutoff (<cutoff>)
```

Renovate writes that lockfile, and it opens the pull request within hours of a publish. `minimumReleaseAge: "3 days"` in `renovate.json5` does not prevent it: when every candidate version fails the age check, `internalChecksFilter` (default `strict`) returns the newest one with `pendingChecks` set instead of withholding the update, so the branch is created and only `renovate/stability-days` goes pending. CI then fails on a lockfile Renovate produced one step earlier.

`trustLockfile: true` makes the install trust the resolutions the lockfile already records. The protection that matters stays in place:

- Resolution time — `pnpm update` and Renovate's own lockfile generation still honour `minimumReleaseAge`.
- Merge time — Renovate's three-day hold still blocks automerge through the pending `renovate/stability-days` check.

The trade-off is that CI no longer re-audits a lockfile supplied by a pull request.

This was verified against `seijikohara/vizel`, where the same failure blocked two dependency pull requests.

## Test Plan

- [x] Run `pnpm install --frozen-lockfile` locally and confirm pnpm accepts the setting.
- [ ] Confirm CI passes on this pull request.
