### PR TITLE
ci: limit push trigger to main to stop duplicate runs

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,6 +2,7 @@ name: Node.js CI
 
 on:
   push:
+    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary

Restrict the `push` trigger of `node.js.yml` to `main`, so each pull request runs CI once instead of twice.

## Problem

`node.js.yml` triggers on `push` with no branch filter while also triggering on
`pull_request`, so every pull request ran the full Node matrix twice against
the same commit.

The workflow declares no `concurrency` group, so the duplicate runs did not
cancel each other and no checks were falsely reported as failing. The cost is
purely wasted CI minutes.

## Changes

### Fixed

- `.github/workflows/node.js.yml`: `on.push` limited to `main`

## Test Plan

- [x] The file parses as valid YAML and resolves to `{push: {branches: [main]}, pull_request: {branches: [main]}}`
- [ ] CI on this pull request produces exactly one `Node.js CI` run